### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: php
 php:
   - 7.1
   - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
   - composer install --no-interaction -o


### PR DESCRIPTION
# Changed log
- Replace `try....catch` with `expectException` and `expectExceptionMessage`.
- Add the `php-nightly` in Travis CI build because it can test the nightly PHP version.
Let that version allow failure because nobody can guarantee that it can be worked well in every Travis CI build.